### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/GraysonBellamy/pyngb/security/code-scanning/1](https://github.com/GraysonBellamy/pyngb/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the `test` job in `.github/workflows/ci-cd.yml`. The minimal required permission for this job is `contents: read`, as it only needs to check out code and does not need to write to the repository or perform privileged actions. This change should be made by inserting the following lines under the `test:` job definition (after line 12, before `name:` on line 13):

```yaml
    permissions:
      contents: read
```

No additional imports, methods, or definitions are needed. This change is isolated to the workflow YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
