### PR TITLE
feat: add mass and DSC normalization to initial sample mass

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -208,10 +208,17 @@ print(result.report())
       heading_level: 3
       show_source: true
 
+### Normalization Functions
+
+::: pyngb.api.analysis.normalize_to_initial_mass
+    options:
+      heading_level: 3
+      show_source: true
+
 ### DTG Analysis Examples
 
 ```python
-from pyngb import dtg, dtg_custom, add_dtg, calculate_table_dtg
+from pyngb import dtg, dtg_custom, add_dtg, calculate_table_dtg, normalize_to_initial_mass
 import numpy as np
 
 # Basic DTG calculation - dead simple
@@ -245,6 +252,14 @@ print(f"Added DTG column. New shape: {table_with_dtg.num_rows} x {table_with_dtg
 # Calculate DTG array from table
 dtg_array = calculate_table_dtg(table, smooth="strict")
 print(f"DTG array shape: {dtg_array.shape}")
+
+# Normalize data to initial sample mass for quantitative analysis
+normalized_table = normalize_to_initial_mass(table)
+print(f"Added normalized columns: {[c for c in normalized_table.column_names if '_normalized' in c]}")
+
+# Combine normalization with DTG analysis
+normalized_with_dtg = add_dtg(normalized_table, column_name="dtg_normalized")
+print(f"Complete analysis table shape: {normalized_with_dtg.num_rows} x {normalized_with_dtg.num_columns}")
 ```
 
 ### Method and Smoothing Comparison

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -191,7 +191,7 @@ if 'dsc_signal' in df.columns:
 ### DTG (Derivative Thermogravimetry) Analysis
 
 ```python
-from pyngb.api.analysis import add_dtg
+from pyngb.api.analysis import add_dtg, normalize_to_initial_mass
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -246,6 +246,16 @@ if 'mass' in df.columns:
     print(f"Maximum mass loss rate: {np.max(np.abs(dtg_values)):.3f} mg/min")
     print(f"Temperature at max rate: {temperature[np.argmax(np.abs(dtg_values))]:.1f}°C")
     print(f"Total mass loss: {mass[0] - mass[-1]:.3f} mg ({((mass[0] - mass[-1])/mass[0]*100):.1f}%)")
+
+    # Normalize data for quantitative cross-sample comparison
+    metadata, _ = read_ngb("sample.ngb-ss3", return_metadata=True)
+    normalized_table = normalize_to_initial_mass(table)
+    df_normalized = pl.from_arrow(normalized_table)
+
+    print(f"\nNormalization Summary:")
+    print(f"Sample mass from metadata: {metadata['sample_mass']:.1f} mg")
+    print(f"Normalized mass range: {df_normalized['mass_normalized'].min():.6f} to {df_normalized['mass_normalized'].max():.6f}")
+    print(f"Added columns: {[c for c in df_normalized.columns if '_normalized' in c]}")
 ```
 
 ### Batch Processing Multiple Files


### PR DESCRIPTION
Add normalize_to_initial_mass() function to api.analysis module that normalizes mass and DSC columns by dividing by initial sample mass from metadata.

Features:
- Creates new columns with '_normalized' suffix, preserving original data
- Defaults to normalizing 'mass' and 'dsc_signal' columns
- Allows custom column selection via columns parameter
- Uses sample_mass from file metadata (handles tared mass correctly)
- Comprehensive error handling and validation
- Full documentation and examples

This enables quantitative cross-sample comparison by expressing results as fractions of initial sample mass, independent of sample size variations.