### PR TITLE
fix: remove invalid custom_dir and fix navigation reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,6 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
-  custom_dir: docs/overrides
   palette:
     - scheme: default
       primary: green
@@ -97,7 +96,6 @@ markdown_extensions:
   - pymdownx.tilde
 
 nav:
-  - Home: ../README.md
   - Getting Started: getting-started.md
   - User Guide: user-guide.md
   - API Reference: api-reference.md


### PR DESCRIPTION
- Remove non-existent custom_dir from mkdocs.yml theme config
- Fix navigation reference to ../README.md (doesn't exist in docs context)
- Use getting-started.md as the entry point instead
- Verified mkdocs build works without warnings